### PR TITLE
Add plotly dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The documentation including tutorials and basic user guide can be found here: [c
     * scikit-learn (1.0.2)
     * lmfit (1.2.2)
     * h5py (3.10.0)
+    * plotly (6.0.1)
       
 ## PIP
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "tqdm>=4.66.1",
     "gudhi>=3.11",
+    "plotly>=6.0.1",
 ]
 classifiers = [
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
It appears that plotly is now required to run portions of cryoCAT – I got a `ModuleNotFoundError` when I tried to run `from cryocat import wedgeutils`. If that's the case, it should be added to the dependencies lists in the README and the pyproject.toml.