### PR TITLE
added relion 5_1 support and fixed issues in sta

### DIFF
--- a/cryocat/cryomotl.py
+++ b/cryocat/cryomotl.py
@@ -1342,8 +1342,12 @@ class Motl:
             return RelionMotl(input_motl, **kwargs)  # kwargs: version, pixel_size, binning, optics_data
         elif motl_type == "relion5":
             return RelionMotlv5(
-                input_motl, **kwargs
+                input_motl, version=5.0, **kwargs
             )  # kwargs: input_tomograms, tomo_idx, pixel_size, binning, optics_data
+        elif motl_type == "relion5_1":
+            return RelionMotlv5_1(
+                input_motl, **kwargs
+            )   # kwargs : input_tomograms, tomo_idx, pixel_size, binning, optics_data
         elif motl_type == "stopgap":
             return StopgapMotl(input_motl)
         elif motl_type == "dynamo":
@@ -2224,6 +2228,25 @@ class RelionMotl(Motl):
         "rlnClassNumber",
     ]
 
+    columns_v5_1 = [
+        "rlnCoordinateX",
+        "rlnCoordinateY",
+        "rlnCoordinateZ",
+        "rlnAngleRot",
+        "rlnAngleTilt",
+        "rlnAnglePsi",
+        "rlnMicrographName",
+        "rlnImageName",
+        "rlnPixelSize",
+        "rlnOpticsGroup",
+        "rlnGroupNumber",
+        "rlnOriginXAngst",
+        "rlnOriginYAngst",
+        "rlnOriginZAngst",
+        "rlnClassNumber",
+        "rlnRandomSubset",
+    ]
+
     def __init__(self, input_motl=None, version=None, pixel_size=None, binning=None, optics_data=None, tomo_format="", subtomo_format=""):
         super().__init__()
         self.version = version
@@ -2264,7 +2287,7 @@ class RelionMotl(Motl):
             self.set_pixel_size()
 
         self.set_version_specific_names()
-        if self.version >= 4.0 and binning is None:
+        if self.version >= 4.0 and self.version != 5.1 and binning is None:
             raise UserInputError("Binning parameter must be specified for this Relion version")
 
     def set_pixel_size(self):
@@ -2371,7 +2394,7 @@ class RelionMotl(Motl):
         """
 
         # pixel size is already set, do not try to get it from the data
-        if self.version is not None:
+        if self.version is not None: #should be always the case with 5.1
             return
 
         if version is not None:
@@ -2471,7 +2494,10 @@ class RelionMotl(Motl):
 
         frames, specifiers, _ = starfileio.Starfile.read(input_path)
 
-        version = RelionMotl.get_version_from_file(frames, specifiers)
+        if self.version is None: #if it was passed by argument then why to do it?
+            version = RelionMotl.get_version_from_file(frames, specifiers)
+        else:
+            version = self.version
 
         data_id = RelionMotl._get_data_particles_id(specifiers)
         optics_id = RelionMotl._get_optics_id(specifiers)
@@ -2660,6 +2686,7 @@ class RelionMotl(Motl):
 
             self.df["tomo_id"] = tomo_idx
 
+        # in case there is no migrograph name fetch tomo id from subtomo path
         elif self.subtomo_id_name in relion_df.columns:
             if self.version <= 3.1 or self.version == 5.1:
                 tomo_position = -1
@@ -2934,7 +2961,7 @@ class RelionMotl(Motl):
             subtomo_id_name = "rlnImageName"
             shifts_id_names = ["rlnOriginX", "rlnOriginY", "rlnOriginZ"]
             data_spec = "data_"
-        elif version == 3.1:
+        elif version == 3.1 or version == 5.1:
             tomo_id_name = "rlnMicrographName"
             subtomo_id_name = "rlnImageName"
             shifts_id_names = ["rlnOriginXAngst", "rlnOriginYAngst", "rlnOriginZAngst"]
@@ -3597,12 +3624,12 @@ class RelionMotlv5(RelionMotl, Motl):
     ]
 
     def __init__(
-        self, input_particles=None, input_tomograms=None, tomo_idx=None, pixel_size=None, binning=1.0, optics_data=None, tomo_format="", subtomo_format=""
+        self, input_particles=None, input_tomograms=None, tomo_idx=None, pixel_size=None, binning=1.0, optics_data=None, tomo_format="", subtomo_format="", version=None
     ):
         Motl.__init__(self, motl_df=None)
 
         self.isWarp = False
-        self.version = 5.0
+        self.version = version if version is not None else 5.0
         self.binning = binning
         self.pixel_size = pixel_size
         self.optics_data = optics_data
@@ -4083,8 +4110,8 @@ class RelionMotlv5(RelionMotl, Motl):
             coords = []
 
             # Precompute the trailing numeric suffix of each rlnTomoName once
-            cleaned_tomo_df = RelionMotlv5.clean_tomo_name_column(self.tomo_df.copy())
-            name_suffix_num = cleaned_tomo_df["rlnTomoName"].astype("Int64")  # nullable int
+            name_suffix_num = self.tomo_df["rlnTomoName"].astype(str).str.extract(r"(\d+)$", expand=False)
+            name_suffix_num = name_suffix_num.astype("Int64")  # nullable int
 
             for idx, row in self.df.iterrows():
                 # tomo_id might be float in the input; interpret it as an int index
@@ -4180,6 +4207,31 @@ class RelionMotlv5(RelionMotl, Motl):
 
         starfileio.Starfile.write(frames, output_path, specifiers=specifiers)
 
+class RelionMotlv5_1:
+    def __new__(
+            cls, input_particles = None, input_tomograms = None, tomo_idx = None, pixel_size = None, binning = None, optics_data = None
+    ):
+        if input_tomograms is None: #single file mode
+            if input_particles is not None:
+                    return RelionMotl(
+                        input_motl=input_particles,
+                        pixel_size=pixel_size,
+                        optics_data=optics_data,
+                        binning=binning,
+                        version=5.1)
+            else:
+                raise UserInputError(
+                    f"RELION5.1 objects can be created either with a single standard .star file either with the format introduced in 5.0 version"
+                )
+        else: #tomo_mode (2 files)
+            return RelionMotlv5(
+                input_particles=input_particles,
+                input_tomograms=input_tomograms,
+                optics_data=optics_data,
+                version=5.1,
+                binning=binning,
+                tomo_idx=tomo_idx
+            )
 
 class StopgapMotl(Motl):
     pairs = {
@@ -4809,11 +4861,12 @@ def emmotl2relion(
     if relion_version < 5.0:
         rln_motl = RelionMotl(input_motl=em_motl.df, version=relion_version, **load_kwargs)
     else:
-        if "input_tomograms" not in load_kwargs:
-            raise UserInputError("For relion5 input_tomogram parameter is mandatory")
+        if relion_version == 5.0:
+            rln_motl = RelionMotlv5(input_particles=em_motl.df, version=relion_version, **load_kwargs)
+        elif relion_version == 5.1:
+            rln_motl = RelionMotlv5_1(input_particles=em_motl.df, **load_kwargs)
         else:
-            rln_motl = RelionMotlv5(input_particles=em_motl.df, **load_kwargs)
-
+            raise UserInputError("Not yet supported relion version")
     if output_motl_path is not None:
         rln_motl.write_out(
             output_motl_path,
@@ -4864,8 +4917,13 @@ def relion2emmotl(
         The converted EmMotl object.
     """
     load_kwargs = load_kwargs or {}
-    if relion_version == 5.0:
-        rln_motl = RelionMotlv5(input_particles=input_motl, pixel_size=pixel_size, binning=binning, **load_kwargs)
+    if relion_version >= 5.0:
+        if relion_version == 5.0:
+            rln_motl = RelionMotlv5(input_particles=input_motl, pixel_size=pixel_size, binning=binning, **load_kwargs)
+        elif relion_version == 5.1:
+            rln_motl = RelionMotlv5_1(input_particles=input_motl, pixel_size=pixel_size, binning=binning, **load_kwargs)
+        else:
+            raise UserInputError("Not yet supported relion version")
     else:
         rln_motl = RelionMotl(input_motl, version=relion_version, pixel_size=pixel_size, binning=binning, **load_kwargs)
 
@@ -4970,8 +5028,11 @@ def relion2stopgap(
         The converted StopgapMotl object.
     """
     load_kwargs = load_kwargs or {}
-    if relion_version == 5.0:
-        motl = RelionMotlv5(input_particles=input_motl, **load_kwargs)
+    if relion_version >= 5.0:
+        if relion_version == 5.0:
+            motl = RelionMotlv5(input_particles=input_motl, version=relion_version, **load_kwargs)
+        elif relion_version == 5.1:
+            motl = RelionMotlv5_1(input_particles=input_motl, **load_kwargs)
     else:
         motl = RelionMotl(input_motl=input_motl, version=relion_version, **load_kwargs)
 
@@ -5030,12 +5091,11 @@ def stopgap2relion(
 
     load_kwargs = load_kwargs or {}
     write_kwargs = write_kwargs or {}
-
-    if relion_version == 5.0:
-        if "input_tomograms" not in load_kwargs:
-            raise UserInputError("For relion5 input_tomogram parameter is mandatory")
-        else:
-            rln_motl = RelionMotlv5(input_particles=sg_motl.df, **load_kwargs)
+    if relion_version >= 5.0:
+        if relion_version == 5.0:
+            rln_motl = RelionMotlv5(input_particles=sg_motl.df, version=relion_version, **load_kwargs)
+        elif relion_version == 5.1:
+            rln_motl = RelionMotlv5_1(input_particles=sg_motl.df, **load_kwargs)
 
     else:
         rln_motl = RelionMotl(input_motl=sg_motl.df, version=relion_version, **load_kwargs)

--- a/cryocat/sta.py
+++ b/cryocat/sta.py
@@ -7,7 +7,7 @@ from cryocat import visplot
 from cryocat import ioutils
 
 
-def get_stable_particles(motl_base_name, start_it, end_it, motl_type="emmotl"):
+def get_stable_particles(motl_base_name, start_it, end_it, motl_type="emmotl", load_kwargs=None):
     """Load and analyze particle data across multiple iterations to identify stable particles, i.e. particles that do
     not change their class.
 
@@ -20,9 +20,12 @@ def get_stable_particles(motl_base_name, start_it, end_it, motl_type="emmotl"):
         Starting iteration number.
     end_it : int
         Ending iteration number.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
-
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
     Returns
     -------
     list
@@ -36,11 +39,11 @@ def get_stable_particles(motl_base_name, start_it, end_it, motl_type="emmotl"):
     iteration is printed.
     """
 
-    motl_ext = get_motl_extension(motl_type)
-
+    load_kwargs = load_kwargs or {}
     dfs = []
     for i in np.arange(start_it, end_it + 1):
-        m = cryomotl.Motl.load(motl_base_name + str(i) + motl_ext, motl_type=motl_type)
+        filename = get_motl_filename(motl_base_name, i, motl_type)
+        m = cryomotl.Motl.load(filename, motl_type=motl_type, **load_kwargs)
         dfs.append(m.df)
 
     # Merge the dataframes on 's_id' column
@@ -71,6 +74,7 @@ def evaluate_alignment(
     labels=None,
     graph_title="Alignment stability",
     graph_output_file=None,
+    load_kwargs=None
 ):
     """Evaluate alignment stability for specified motls and iterations.
 
@@ -104,6 +108,10 @@ def evaluate_alignment(
         Title of the graph. Used only if plot_values is True. Defaults to "Alignment stability".
     graph_output_file  : str, optional
         Output file for the graph. Used only if plot_values is True. If None no file will be written out. Defaults to None.
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
 
     Returns
     -------
@@ -178,6 +186,7 @@ def evaluate_alignment(
             filter_rows = filter_rows * len(motl_base_names)
 
     stats_dfs = []
+    load_kwargs = load_kwargs or {}
     for i, m in enumerate(motl_base_names):
         if write_out_stats:
             stats_file_name = m + f"as_{str(i+1)}.csv"
@@ -192,6 +201,7 @@ def evaluate_alignment(
                 filter_rows=filter_rows[i],
                 filter_column=filter_columns[i],
                 output_file=stats_file_name,
+                load_kwargs=load_kwargs
             )
         )
 
@@ -210,7 +220,7 @@ def get_motl_extension(motl_type):
 
     Parameters
     ----------
-    motl_type : str (emmotl|relion|stopgap)
+    motl_type : str (emmotl|relion|relion5|relion5_1|stopgap)
         The type of motl file.
 
     Returns
@@ -224,13 +234,12 @@ def get_motl_extension(motl_type):
         If the motl type is not supported.
     """
 
-    if motl_type == "stopgap" or motl_type == "relion":
+    if motl_type in ["stopgap", "relion", "relion5", "relion5_1"]:
         motl_ext = ".star"
     elif motl_type == "emmotl":
         motl_ext = ".em"
     else:
-        raise ValueError(f"The motl type {motl_type} is not cyrrently supported.")
-
+        raise ValueError(f"The motl type {motl_type} is not currently supported.")
     return motl_ext
 
 
@@ -242,6 +251,7 @@ def compute_alignment_statistics(
     filter_rows=None,
     filter_column="subtomo_id",
     output_file=None,
+    load_kwargs=None
 ):
     """Compute alignment statistics for specified motls and iterations. Pairs of (current motl, subsequent motl) are
     evaluated for differences in cone angles, in-plane angles, change in positions of particles and root mean square
@@ -257,7 +267,7 @@ def compute_alignment_statistics(
         Starting iteration number.
     end_it : int
         Ending iteration number.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
     filter_rows : array-like, optional
         Rows to filter. Only rows that are within the filter_rows will be kept. Defaults to None which means no filtering.
@@ -266,6 +276,10 @@ def compute_alignment_statistics(
         this parameter will not be used. Defaults to "subtomo_id".
     output_file : str, optional
         Output file for the statistics. If None no file will be written out. Defaults to None.
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
 
     Returns
     -------
@@ -290,7 +304,6 @@ def compute_alignment_statistics(
     ... )
     """
 
-    motl_ext = get_motl_extension(motl_type)
 
     stats_df = pd.DataFrame(
         columns=[
@@ -314,8 +327,10 @@ def compute_alignment_statistics(
 
     # load motls
     motls = []
+    load_kwargs = load_kwargs or {}
     for i in np.arange(start_it, end_it + 1):
-        m = cryomotl.Motl.load(motl_base_name + str(i) + motl_ext, motl_type=motl_type)
+        filename = get_motl_filename(motl_base_name, i, motl_type)
+        m = cryomotl.Motl.load(filename, motl_type=motl_type, **load_kwargs)
         if filter_rows is not None:
             m.df = m.df[m.df[filter_column].isin(filter_rows)]
         motls.append(m)
@@ -355,7 +370,7 @@ def write_out_motl(input_motl, output_file_base, output_motl_type):
         Input motl file to be written out.
     output_file_base : str
         Base name for the output file.
-    output_motl_type : str (emfile|relion|stopgap)
+    output_motl_type : str (emfile|relion|relion5|relion5_1|stopgap)
         Type of the output motl file.
 
     Raises
@@ -373,6 +388,12 @@ def write_out_motl(input_motl, output_file_base, output_motl_type):
         final_motl.write_out(output_file_base + ".star", reset_index=True)
     elif output_motl_type == "relion":
         final_motl = cryomotl.RelionMotl(input_motl.df)
+        final_motl.write_out(output_file_base + ".star")
+    elif output_motl_type == "relion5":
+        final_motl = cryomotl.RelionMotlv5(input_motl.df)
+        final_motl.write_out(output_file_base + ".star")
+    elif output_motl_type == "relion5_1":
+        final_motl = cryomotl.RelionMotlv5_1(input_motl.df)
         final_motl.write_out(output_file_base + ".star")
     elif output_motl_type == "emfile":
         final_motl = cryomotl.EmMotl(input_motl.df)
@@ -404,7 +425,7 @@ def create_multiref_run(
         Base path for the output motl files. The final name will be created as output_motl_base_mr#runID_iterationNumber
         where runID is from 1 to number_of_runs and iterationNumber is iteration_number. The extension will be determined
         based on the output_motl_type.
-    input_motl_type : str (emmotl|stopgap|relion), default="emmotl"
+    input_motl_type : str (emmotl|stopgap|relion|relion5|relion5_1), default="emmotl"
         Type of the input motl file. Defaults to "emmotl".
     iteration_number : int, default=1
         Iteration number to be used in the output name creation. Defaults to 1.
@@ -466,7 +487,7 @@ def create_denovo_multiref_run(
         Base path for the output motl files. The final name will be created as output_motl_base_ref_mr#runID_iterationNumber
         where runID is from 1 to number_of_runs and iterationNumber is iteration_number. The alignment motl will be named
         output_motl_base_iterationNumber. In both cases, the extension will be determined based on the output_motl_type.
-    input_motl_type : str (emmotl|stopgap|relion), default="emmotl"
+    input_motl_type : str (emmotl|stopgap|relion|relion5|relion5_1), default="emmotl"
         Type of the input motl file. Defaults to "emmotl".
     class_occupancy : int, optional
         Number of particles per class for the reference averaging motls. If None, the number is determined as 1/10
@@ -533,7 +554,7 @@ def evaluate_multirun_stability(input_motls, input_motl_type="stopgap"):
     ----------
     input_motls: list
         List of input motl files. At least two are required.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
 
     Returns
@@ -571,7 +592,7 @@ def evaluate_multirun_stability(input_motls, input_motl_type="stopgap"):
     return common_occupancies
 
 
-def get_subtomos_class_stability(motl_base_name, start_it, end_it, motl_type="stopgap"):
+def get_subtomos_class_stability(motl_base_name, start_it, end_it, motl_type="stopgap", load_kwargs=None):
     """Calculate the class stability of subtomograms over iterations.
 
     Parameters
@@ -583,8 +604,12 @@ def get_subtomos_class_stability(motl_base_name, start_it, end_it, motl_type="st
         Starting iteration number.
     end_it : int
         Ending iteration number.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
 
     Returns
     -------
@@ -598,11 +623,11 @@ def get_subtomos_class_stability(motl_base_name, start_it, end_it, motl_type="st
     only once.
     """
 
-    motl_ext = get_motl_extension(motl_type)
-
     dfs = []
+    load_kwargs = load_kwargs or {}
     for i in np.arange(start_it, end_it + 1):
-        m = cryomotl.Motl.load(motl_base_name + str(i) + motl_ext, motl_type=motl_type)
+        filename = get_motl_filename(motl_base_name, i, motl_type)
+        m = cryomotl.Motl.load(filename, motl_type=motl_type, **load_kwargs)
         dfs.append(m.df)
 
     # Concatenate the list of DataFrames into a single DataFrame
@@ -627,6 +652,7 @@ def evaluate_classification(
     output_file_stats=None,
     plot_results=False,
     output_file_graphs=None,
+    load_kwargs=None
 ):
     """Get the occupancy of each class over the iterations and the class stability of subtomograms over iterations.
 
@@ -639,7 +665,7 @@ def evaluate_classification(
         Starting iteration number.
     end_it : int
         Ending iteration number.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
     output_file_stats : str, optional
         Name of the file into which the results will be written out. If None, no results will be written out. Defaults
@@ -649,7 +675,10 @@ def evaluate_classification(
     output_file_graphs: str, optional
         Name of the file into which the plotted graphs will be written out. If None, the graphs will not be written out.
         If plot_results is False, this parameter is unused. Defaults to None.
-
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
     Returns
     -------
     occupancy : dict
@@ -658,11 +687,11 @@ def evaluate_classification(
         A dictionary containing the number of different subtomogram IDs for each class over iterations.
     """
 
-    motl_ext = get_motl_extension(motl_type)
-
     dfs = []
+    load_kwargs = load_kwargs or {}
     for i in np.arange(start_it, end_it + 1):
-        m = cryomotl.Motl.load(motl_base_name + str(i) + motl_ext, motl_type=motl_type)
+        filename = get_motl_filename(motl_base_name, i, motl_type)
+        m = cryomotl.Motl.load(filename, motl_type=motl_type, **load_kwargs)
         dfs.append(m.df)
 
     # Create a dictionary to store the occupancy of each class per dataframe
@@ -710,7 +739,7 @@ def evaluate_classification(
     return occupancy, changing_subtomos
 
 
-def get_class_occupancy(motl_base_name, start_it, end_it, motl_type="stopgap"):
+def get_class_occupancy(motl_base_name, start_it, end_it, motl_type="stopgap", load_kwargs=None):
     """Get the occupancy of each class over the iterations.
 
     Parameters
@@ -722,8 +751,12 @@ def get_class_occupancy(motl_base_name, start_it, end_it, motl_type="stopgap"):
         Starting iteration number.
     end_it : int
         Ending iteration number.
-    motl_type : str (stopgap|emmotl|relion), default="stopgap"
+    motl_type : str (stopgap|emmotl|relion|relion5|relion5_1), default="stopgap"
         Type of the input motl. Defaults to "stopgap".
+    load_kwargs : dict, optional
+        Dictionary of keyword arguments passed to the `Motl.load` method (and subsequently to the underlying
+        Motl class constructors like 'RelionMotl' and `RelionMotlv5`). This is useful for providing necessary metadata like
+        `pixel_size`, `binning`, `optics_data`, or custom formats (`tomo_format`, `subtomo_format`). Defaults to None.
 
     Returns
     -------
@@ -736,12 +769,11 @@ def get_class_occupancy(motl_base_name, start_it, end_it, motl_type="stopgap"):
     use :meth:`cryocat.sta.evaluate_classification` which gives both occupancy and stability and reads in all the motls
     only once.
     """
-
-    motl_ext = get_motl_extension(motl_type)
-
+    load_kwargs = load_kwargs or {}
     dfs = []
     for i in np.arange(start_it, end_it + 1):
-        m = cryomotl.Motl.load(motl_base_name + str(i) + motl_ext, motl_type=motl_type)
+        filename = get_motl_filename(motl_base_name, i, motl_type)
+        m = cryomotl.Motl.load(filename, motl_type=motl_type, **load_kwargs)
         dfs.append(m.df)
 
     # Create a dictionary to store the occupancy of each class per dataframe
@@ -753,3 +785,10 @@ def get_class_occupancy(motl_base_name, start_it, end_it, motl_type="stopgap"):
             occupancy[c][i] = len(df[df["class"] == c])
 
     return occupancy
+
+def get_motl_filename(motl_base_name, iteration, motl_type):
+    if "relion" in motl_type:
+        return f"{motl_base_name}{str(iteration).zfill(3)}_data.star"
+    else:
+        motl_ext = get_motl_extension(motl_type)
+        return f"{motl_base_name}{iteration}{motl_ext}"

--- a/tests/test_cryomotl.py
+++ b/tests/test_cryomotl.py
@@ -11,7 +11,7 @@ import unittest
 import os
 
 from cryocat import ioutils, cryomap, cryomask, geom
-from cryocat.cryomotl import Motl, EmMotl, RelionMotl, RelionMotlv5, StopgapMotl, DynamoMotl, ModMotl, stopgap2emmotl, emmotl2stopgap
+from cryocat.cryomotl import Motl, EmMotl, RelionMotl, RelionMotlv5, RelionMotlv5_1, StopgapMotl, DynamoMotl, ModMotl, stopgap2emmotl, emmotl2stopgap
 from cryocat.exceptions import UserInputError
 from scipy.spatial.transform import Rotation as rot
 from pathlib import Path
@@ -2333,6 +2333,7 @@ class TestRelionMotl:
             "relion30_path": test_data + "/motl_data/relion_3.0.star",
             "relion31_path": test_data + "/motl_data/relion_3.1_optics2.star",
             "relion40_path": test_data + "/motl_data/relion_4.0.star",
+            "relion51_path": test_data + "/motl_data/relion5_1/run_it025_data.star",
             "relionbroken_path": test_data + "/motl_data/bin1_1deg_500.star"
         }
 
@@ -2346,6 +2347,7 @@ class TestRelionMotl:
         motl.set_version(pd.DataFrame(), version=3.0)
         assert motl.version == 3.1 #Should not be changed: default is 3.1 and after set
         #It can't be changed!
+
 
     def test_set_version_from_dataframe_v4(self):
         df = pd.DataFrame({"rlnTomoName": [1]})
@@ -2510,6 +2512,10 @@ class TestRelionMotl:
         relion123 = RelionMotl(test_data + "/motl_data/bin1_1deg_500_2.star")
         #normally read as the other ones
         print(relion123.relion_df)
+
+        #test with relion5.1 file
+        relion_motl_v51 = RelionMotlv5_1(relion_paths['relion51_path'])
+        assert relion_motl_v51.version == 5.1
 
     def test_get_version_from_file(self, relion_paths):
         frames3_0, spec3_0, _ = starfileio.Starfile.read(relion_paths['relion30_path'])
@@ -5692,3 +5698,4 @@ class TestRelionMotlv5:
             "rlnAmplitudeContrast": [0.1],
         })
         pd.testing.assert_frame_equal(optics_df, expected_df)
+

--- a/tests/test_sta.py
+++ b/tests/test_sta.py
@@ -97,6 +97,51 @@ def test_get_motl_extension():
         assert "unsupported" in str(e).lower()
 
 
+def test_get_motl_filename():
+    assert get_motl_filename("run_", 1, "stopgap") == "run_1.star"
+    assert get_motl_filename("run_", 10, "emmotl") == "run_10.em"
+
+    assert get_motl_filename("run_it", 1, "relion") == "run_it001_data.star"
+    assert get_motl_filename("run_it", 12, "relion5") == "run_it012_data.star"
+    assert get_motl_filename("run_it", 999, "relion5_1") == "run_it999_data.star"
+
+
+def test_get_class_occupancy_relion():
+    df1 = pd.DataFrame({
+        'rlnCoordinateX': [100.0, 200.0],
+        'rlnCoordinateY': [100.0, 200.0],
+        'rlnCoordinateZ': [100.0, 200.0],
+        'rlnAngleRot': [0.0, 0.0],
+        'rlnAngleTilt': [0.0, 0.0],
+        'rlnAnglePsi': [0.0, 0.0],
+        'rlnImageName': ['000001@1.mrc', '000002@1.mrc'],
+        'rlnMicrographName': ['1.mrc', '1.mrc'],
+        'rlnClassNumber': [1, 2]
+    })
+    df2 = pd.DataFrame({
+        'rlnCoordinateX': [100.0, 200.0],
+        'rlnCoordinateY': [100.0, 200.0],
+        'rlnCoordinateZ': [100.0, 200.0],
+        'rlnAngleRot': [0.0, 0.0],
+        'rlnAngleTilt': [0.0, 0.0],
+        'rlnAnglePsi': [0.0, 0.0],
+        'rlnImageName': ['000001@1.mrc', '000002@1.mrc'],
+        'rlnMicrographName': ['1.mrc', '1.mrc'],
+        'rlnClassNumber': [1, 1]
+    })
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = os.path.join(tmpdir, "run_it")
+        rm1 = cryomotl.RelionMotl(df1)
+        rm2 = cryomotl.RelionMotl(df2)
+        rm1.write_out(f"{base_path}001_data.star")
+        rm2.write_out(f"{base_path}002_data.star")
+        occupancy = get_class_occupancy(base_path, 1, 2, motl_type="relion")
+        expected = {
+            1: [1, 2],
+            2: [1, 0]
+        }
+        assert occupancy == expected
+
 def test_compute_alignment_statistics(sg_mock):
     with tempfile.TemporaryDirectory() as tmpdir:
         motl_base = os.path.join(tmpdir, "motl_")


### PR DESCRIPTION
- cryomotl.py : added RelionMotlv5_1 class factory to reroute objects as v3.1 or v5.0 and adapted existing classes accordingly; added support with conversion functions
 - sta.py: created function get_motl_filename to parse accordingly relion files; added possibility to use kwargs